### PR TITLE
Center topbar items

### DIFF
--- a/css/modern.css
+++ b/css/modern.css
@@ -12,7 +12,8 @@ body {
   gap: 1.5rem;
   padding: 0.5rem 2rem;
   font-size: 0.9rem;
-  margin-left: -1.2rem;
+  /* Remove left offset so items can truly center */
+  margin-left: 0;
 }
 
 .topbar ul {
@@ -20,7 +21,8 @@ body {
   margin: 0;
   display: flex;
   gap: 1.2rem;
-  padding-left: 9.5rem;
+  /* Remove extra padding to allow centering */
+  padding-left: 0;
 }
 
 .topbar ul li a {

--- a/css/style.css
+++ b/css/style.css
@@ -1463,7 +1463,8 @@ margin-left: 15rem;
   padding: 5px 0;
   display: flex;
   justify-content: center;
-  margin-left: -1.2rem;
+  /* Remove left offset so items center */
+  margin-left: 0;
   color:  #002244;
 }
 
@@ -1471,7 +1472,8 @@ margin-left: 15rem;
 .topbar ul {
   list-style: none;
   margin: 0;
-  padding-left: 9.5rem;
+  /* Remove extra padding to allow centering */
+  padding-left: 0;
   display: flex;
   gap: 20px;
 }
@@ -3171,7 +3173,8 @@ margin-left: 15rem;
   padding: 5px 0;
   display: flex;
   justify-content: center;
-  margin-left: -1.2rem;
+  /* Remove left offset so items center */
+  margin-left: 0;
   color:  #002244;
 }
 
@@ -3179,7 +3182,8 @@ margin-left: 15rem;
 .topbar ul {
   list-style: none;
   margin: 0;
-  padding-left: 9.5rem;
+  /* Remove extra padding to allow centering */
+  padding-left: 0;
   display: flex;
   gap: 20px;
 }


### PR DESCRIPTION
## Summary
- remove large left offsets on `.topbar` and `.topbar ul`
- keep modernized layout consistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684193d7e058832da608e7c65720e861