### PR TITLE
Add Google Translate language switcher

### DIFF
--- a/17025.html
+++ b/17025.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <header class="main-header">
@@ -142,5 +143,11 @@
   })();
 </script>
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -174,5 +175,11 @@
 
   <!-- JavaScript -->
   <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/careers.html
+++ b/careers.html
@@ -19,6 +19,7 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -213,6 +214,12 @@
 </div>
 <script src="https://cdn.emailjs.com/sdk/2.3.2/email.min.js"></script>
   <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/ceo.html
+++ b/ceo.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -135,6 +136,12 @@
     <p>&copy; 2025 SeAH Steel UAE LLC. All rights reserved.</p>
   </footer>
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <!--Start of Tawk.to Script-->
 <script type="text/javascript">
 var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();

--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <!-- HEADER -->
@@ -171,6 +172,12 @@ s0.parentNode.insertBefore(s1,s0);
 
 <!-- Map and Scripts -->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC6jeni5WjsZMffUdFjNe5TGUmC1C-FDWU&callback=initUaeMap" async defer></script>
 
 </body>

--- a/css/modern.css
+++ b/css/modern.css
@@ -8,7 +8,8 @@ body {
   background: #f0f0f0;
   color: #003366;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
   gap: 1.5rem;
   padding: 0.5rem 2rem;
   font-size: 0.9rem;
@@ -33,6 +34,9 @@ body {
 
 .topbar ul li a:hover {
   text-decoration: underline;
+}
+.language-switcher {
+  margin-left: auto;
 }
 
 .main-header {

--- a/css/style.css
+++ b/css/style.css
@@ -1460,9 +1460,10 @@ margin-left: 15rem;
 /*top bar */
 .topbar {
   background-color: #d3d3d3;
-  padding: 5px 0;
+  padding: 5px 20px;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
   /* Remove left offset so items center */
   margin-left: 0;
   color:  #002244;
@@ -1493,6 +1494,9 @@ font-weight: bold;
 .topbar ul li a:hover {
   text-decoration: underline;
   color: #fff;
+}
+.language-switcher {
+  margin-left: auto;
 }
 .navbar ul li a:hover {
     text-decoration: underline;
@@ -3170,9 +3174,10 @@ margin-left: 15rem;
 /*top bar */
 .topbar {
   background-color: #d3d3d3;
-  padding: 5px 0;
+  padding: 5px 20px;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
   /* Remove left offset so items center */
   margin-left: 0;
   color:  #002244;
@@ -3203,6 +3208,9 @@ font-weight: bold;
 .topbar ul li a:hover {
   text-decoration: underline;
   color: #fff;
+}
+.language-switcher {
+  margin-left: auto;
 }
 .navbar ul li a:hover {
     text-decoration: underline;

--- a/downloads.html
+++ b/downloads.html
@@ -19,6 +19,7 @@
       <li><a href="downloads.html" class="active">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -141,5 +142,11 @@
     })();
   </script>
   <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/globalseah.html
+++ b/globalseah.html
@@ -20,6 +20,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html" class="active">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <!-- HEADER -->
@@ -94,6 +95,12 @@
 
 <!-- SCRIPTS -->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC6jeni5WjsZMffUdFjNe5TGUmC1C-FDWU&callback=initGlobalMap" async defer></script>
 
 </body>

--- a/inauguration.html
+++ b/inauguration.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <header class="main-header">
@@ -135,5 +136,11 @@
   })();
 </script>
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
   <!-- HEADER -->
@@ -237,6 +238,12 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/manufacturing.html
+++ b/manufacturing.html
@@ -47,6 +47,7 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -254,6 +255,12 @@
   <!-- SCRIPTS -->
   <!-- keep your shared script for search/map/etc -->
   <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <!-- then the manufacturing-only modal logic -->
   <script src="js/manufacturing.js"></script>
 </body>

--- a/miite.html
+++ b/miite.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -210,6 +211,12 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -180,5 +181,11 @@ s0.parentNode.insertBefore(s1,s0);
 
 
 
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -207,5 +208,11 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -22,6 +22,7 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER (identical to about.html) -->
@@ -134,5 +135,11 @@
 
   <!-- project grid logic -->
   <script src="js/projects.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/quality.html
+++ b/quality.html
@@ -75,6 +75,7 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -347,6 +348,12 @@
     })();
   </script>
   <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <script>
     document.getElementById('downloadBtn').addEventListener('click', function() {
       document.getElementById('certGrid').classList.toggle('hidden');

--- a/quote.html
+++ b/quote.html
@@ -18,6 +18,7 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -125,5 +126,11 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
+<!-- Google Translate --><script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add language switcher element across all pages
- load Google Translate widget with English, Korean and Arabic
- adjust topbar styles to align language selector to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68419a04b144832d8cbd4584873dd301