### PR TITLE
Add language switcher with Google Translate

### DIFF
--- a/17025.html
+++ b/17025.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
 
 <header class="main-header">
@@ -36,6 +41,11 @@
       <li><a href="news.html" class="active">News</a></li>
       <li><a href="contact.html">Contact</a></li>
     </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
   </nav>
   <a href="quote.html" class="quote-btn">Request Quote</a>
 </header>
@@ -109,6 +119,11 @@
         <li><a href="contact.html">Contact</a></li>
         <li><a href="quote.html">Request Quote</a></li>
       </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
     </div>
     <div class="footer-col">
       <h4>Connect With Us</h4>
@@ -141,6 +156,13 @@
     s0.parentNode.insertBefore(s1,s0);
   })();
 </script>
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -171,6 +176,13 @@
       s0.parentNode.insertBefore(s1,s0);
     })();
   </script>
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
   <!-- JavaScript -->
   <script src="js/script.js"></script>

--- a/careers.html
+++ b/careers.html
@@ -19,6 +19,11 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+    <div class="language-switcher">
+      <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+      <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+      <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+    </div>
   </div>
 
   <!-- HEADER -->
@@ -164,6 +169,13 @@
       s0.parentNode.insertBefore(s1,s0);
     })();
   </script>
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 <!-- Application Modal -->
 <div id="applicationModal" class="modal">

--- a/ceo.html
+++ b/ceo.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -148,6 +153,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
 
 <!-- HEADER -->
@@ -168,6 +173,14 @@ s1.setAttribute('crossorigin','*');
 s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
+
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 <!-- Map and Scripts -->
 <script src="js/script.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1495,6 +1495,20 @@ font-weight: bold;
   text-decoration: underline;
   color: #fff;
 }
+.language-switcher {
+  display: flex;
+  gap: 10px;
+}
+.language-switcher a {
+  color: #003366;
+  text-decoration: none;
+  font-weight: bold;
+  margin-left: 10px;
+}
+.language-switcher a:hover {
+  text-decoration: underline;
+  color: #fff;
+}
 .navbar ul li a:hover {
     text-decoration: underline;
     color: #fff;
@@ -3203,6 +3217,20 @@ font-weight: bold;
 }
 
 .topbar ul li a:hover {
+  text-decoration: underline;
+  color: #fff;
+}
+.language-switcher {
+  display: flex;
+  gap: 10px;
+}
+.language-switcher a {
+  color: #003366;
+  text-decoration: none;
+  font-weight: bold;
+  margin-left: 10px;
+}
+.language-switcher a:hover {
   text-decoration: underline;
   color: #fff;
 }

--- a/downloads.html
+++ b/downloads.html
@@ -19,6 +19,11 @@
       <li><a href="downloads.html" class="active">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+    <div class="language-switcher">
+      <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+      <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+      <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+    </div>
   </div>
 
   <!-- HEADER -->
@@ -140,6 +145,13 @@
       s0.parentNode.insertBefore(s1,s0);
     })();
   </script>
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/globalseah.html
+++ b/globalseah.html
@@ -20,6 +20,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html" class="active">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
 
 <!-- HEADER -->
@@ -91,6 +96,14 @@
 <footer>
   <p>&copy; 2025 SeAH Steel UAE LLC. All rights reserved.</p>
 </footer>
+
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 <!-- SCRIPTS -->
 <script src="js/script.js"></script>

--- a/inauguration.html
+++ b/inauguration.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
 
 <header class="main-header">
@@ -134,6 +139,13 @@
     s0.parentNode.insertBefore(s1,s0);
   })();
 </script>
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
 
   <!-- HEADER -->
@@ -236,6 +241,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -843,3 +843,12 @@ function closeMachineModal() {
   modal.classList.remove("open");
 }
 
+// Language switcher using Google Translate
+function setLanguage(lang) {
+  var translateCookie = '/en/' + lang;
+  document.cookie = 'googtrans=' + translateCookie + ';path=/';
+  document.cookie = 'googtrans=' + translateCookie + ';domain=' + window.location.hostname + ';path=/';
+  window.location.reload();
+}
+window.setLanguage = setLanguage;
+

--- a/manufacturing.html
+++ b/manufacturing.html
@@ -47,6 +47,11 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+    <div class="language-switcher">
+      <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+      <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+      <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+    </div>
   </div>
 
   <!-- HEADER -->
@@ -250,6 +255,14 @@
   <footer>
     <p>&copy; 2025 SeAH Steel UAE LLC. All rights reserved.</p>
   </footer>
+
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
   <!-- SCRIPTS -->
   <!-- keep your shared script for search/map/etc -->

--- a/miite.html
+++ b/miite.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -209,6 +214,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 
 </body>

--- a/news.html
+++ b/news.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -152,6 +157,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     const items = document.querySelectorAll(".news-item");

--- a/products.html
+++ b/products.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -206,6 +211,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -22,6 +22,11 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+    <div class="language-switcher">
+      <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+      <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+      <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+    </div>
   </div>
 
   <!-- HEADER (identical to about.html) -->
@@ -131,6 +136,13 @@
       s0.parentNode.insertBefore(s1,s0);
     })();
   </script>
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
   <!-- project grid logic -->
   <script src="js/projects.js"></script>

--- a/quality.html
+++ b/quality.html
@@ -75,6 +75,11 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
+    <div class="language-switcher">
+      <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+      <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+      <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+    </div>
   </div>
 
   <!-- HEADER -->
@@ -346,6 +351,13 @@
       s0.parentNode.insertBefore(s1, s0);
     })();
   </script>
+  <div id="google_translate_element" style="display:none;"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <script src="js/script.js"></script>
   <script>
     document.getElementById('downloadBtn').addEventListener('click', function() {

--- a/quote.html
+++ b/quote.html
@@ -18,6 +18,11 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
+  <div class="language-switcher">
+    <a href="#" onclick="setLanguage('en')">ENGLISH</a>
+    <a href="#" onclick="setLanguage('ar')">ARABIC</a>
+    <a href="#" onclick="setLanguage('ko')">KOREAN</a>
+  </div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -124,6 +129,13 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
+<div id="google_translate_element" style="display:none;"></div>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,ar,ko'}, 'google_translate_element');
+  }
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add language switcher styles
- hook Google Translate cookie logic in script.js
- insert ENGLISH/ARABIC/KOREAN options in top bar of pages
- load Google Translate widget on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a02ab390832d9e283b823c8b254b