### PR TITLE
Remove google translate bar

### DIFF
--- a/17025.html
+++ b/17025.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <header class="main-header">
@@ -143,11 +142,5 @@
   })();
 </script>
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -175,11 +174,5 @@
 
   <!-- JavaScript -->
   <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/careers.html
+++ b/careers.html
@@ -19,7 +19,6 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -214,12 +213,6 @@
 </div>
 <script src="https://cdn.emailjs.com/sdk/2.3.2/email.min.js"></script>
   <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/ceo.html
+++ b/ceo.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -136,12 +135,6 @@
     <p>&copy; 2025 SeAH Steel UAE LLC. All rights reserved.</p>
   </footer>
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <!--Start of Tawk.to Script-->
 <script type="text/javascript">
 var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();

--- a/contact.html
+++ b/contact.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <!-- HEADER -->
@@ -172,12 +171,6 @@ s0.parentNode.insertBefore(s1,s0);
 
 <!-- Map and Scripts -->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC6jeni5WjsZMffUdFjNe5TGUmC1C-FDWU&callback=initUaeMap" async defer></script>
 
 </body>

--- a/css/modern.css
+++ b/css/modern.css
@@ -35,9 +35,6 @@ body {
 .topbar ul li a:hover {
   text-decoration: underline;
 }
-.language-switcher {
-  margin-left: auto;
-}
 
 .main-header {
   /* Match the top bar background */

--- a/css/style.css
+++ b/css/style.css
@@ -1495,9 +1495,6 @@ font-weight: bold;
   text-decoration: underline;
   color: #fff;
 }
-.language-switcher {
-  margin-left: auto;
-}
 .navbar ul li a:hover {
     text-decoration: underline;
     color: #fff;
@@ -3208,9 +3205,6 @@ font-weight: bold;
 .topbar ul li a:hover {
   text-decoration: underline;
   color: #fff;
-}
-.language-switcher {
-  margin-left: auto;
 }
 .navbar ul li a:hover {
     text-decoration: underline;

--- a/downloads.html
+++ b/downloads.html
@@ -19,7 +19,6 @@
       <li><a href="downloads.html" class="active">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -142,11 +141,5 @@
     })();
   </script>
   <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/globalseah.html
+++ b/globalseah.html
@@ -20,7 +20,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html" class="active">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <!-- HEADER -->
@@ -95,12 +94,6 @@
 
 <!-- SCRIPTS -->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC6jeni5WjsZMffUdFjNe5TGUmC1C-FDWU&callback=initGlobalMap" async defer></script>
 
 </body>

--- a/inauguration.html
+++ b/inauguration.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
 <header class="main-header">
@@ -136,11 +135,5 @@
   })();
 </script>
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
 
   <!-- HEADER -->
@@ -238,12 +237,6 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/manufacturing.html
+++ b/manufacturing.html
@@ -47,7 +47,6 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -255,12 +254,6 @@
   <!-- SCRIPTS -->
   <!-- keep your shared script for search/map/etc -->
   <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <!-- then the manufacturing-only modal logic -->
   <script src="js/manufacturing.js"></script>
 </body>

--- a/miite.html
+++ b/miite.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -211,12 +210,6 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -181,11 +180,5 @@ s0.parentNode.insertBefore(s1,s0);
 
 
 
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -208,11 +207,5 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -22,7 +22,6 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER (identical to about.html) -->
@@ -135,11 +134,5 @@
 
   <!-- project grid logic -->
   <script src="js/projects.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/quality.html
+++ b/quality.html
@@ -75,7 +75,6 @@
       <li><a href="downloads.html">Downloads</a></li>
       <li><a href="globalseah.html">Global SeAH</a></li>
     </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
   </div>
 
   <!-- HEADER -->
@@ -348,12 +347,6 @@
     })();
   </script>
   <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <script>
     document.getElementById('downloadBtn').addEventListener('click', function() {
       document.getElementById('certGrid').classList.toggle('hidden');

--- a/quote.html
+++ b/quote.html
@@ -18,7 +18,6 @@
     <li><a href="downloads.html">Downloads</a></li>
     <li><a href="globalseah.html">Global SeAH</a></li>
   </ul>
-  <div class="language-switcher" id="google_translate_element"></div>
 </div>
   <!-- HEADER -->
   <header class="main-header">
@@ -126,11 +125,5 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
 <script src="js/script.js"></script>
-<!-- Google Translate --><script type="text/javascript">
-function googleTranslateElementInit() {
-  new google.translate.TranslateElement({pageLanguage: "en", includedLanguages: "en,ko,ar", layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL}, "google_translate_element");
-}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip google translate snippet from all HTML pages
- remove language switcher CSS blocks

## Testing
- `grep -R "google_translate_element" -n *.html`


------
https://chatgpt.com/codex/tasks/task_e_68419e1c58f8832dbfd237d1d2430faa