### PR TITLE
Fix: Hide Google Translate banner

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3546,3 +3546,11 @@ font-weight: bold;
   cursor: pointer;
 }
 
+
+/* Hide Google Translate top bar */
+iframe.goog-te-banner-frame, .goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+body {
+  top: 0 !important;
+}


### PR DESCRIPTION
## Summary
- hide Google Translate banner from the top of the page using CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a34d28e8832da7c800b5fe6b552e